### PR TITLE
add gitignore for scraped content

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,7 @@
 myenv
+
+# Ignore scraped content apart from examples
+scraping-candidate-websites/scraped_content/*
+!scraping-candidate-websites/scraped_content/20500_Guy_Ingerson
+!scraping-candidate-websites/scraped_content/21097_Lynn_Thomson
+!scraping-candidate-websites/scraped_content/34215_David_Duguid


### PR DESCRIPTION
Minor change to .gitignore to ignore scraped content (apart from the 3 example sites) to avoid large volumes of html files being pushed.